### PR TITLE
Assume current working dir if none is provided

### DIFF
--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -51,15 +51,24 @@ func (c *command) Run(args []string) int {
 	flags.BoolVar(&csv, "csv", false, "CSV output")
 	flags.Parse(args)
 
-	var providerRepoName string
+	var providerPath string
 	if len(args) > 0 {
-		providerRepoName = args[len(args)-1]
+		var err error
+		providerRepoName := args[len(args)-1]
+		providerPath, err = util.GetProviderPath(providerRepoName)
+		if err != nil {
+			log.Printf("Error finding provider %s: %s", providerRepoName, err)
+			return 1
+		}
+	} else {
+		var err error
+		providerPath, err = os.Getwd()
+		if err != nil {
+			log.Printf("Error finding current working directory: %s", err)
+			return 1
+		}
 	}
-	providerPath, err := util.GetProviderPath(providerRepoName)
-	if err != nil {
-		log.Printf("Error finding provider %s: %s", providerRepoName, err)
-		return 1
-	}
+
 	ui := &cli.ColoredUi{
 		OutputColor: cli.UiColorNone,
 		InfoColor:   cli.UiColorBlue,
@@ -101,7 +110,7 @@ func (c *command) Run(args []string) int {
 		if !csv {
 			ui.Output("Checking version of github.com/hashicorp/terraform SDK used in provider...")
 		}
-		SDKVersion, SDKVersionSatisfiesConstraint, err = CheckProviderSDKVersion(providerPath)
+		SDKVersion, SDKVersionSatisfiesConstraint, err := CheckProviderSDKVersion(providerPath)
 		if !csv {
 			if SDKVersionSatisfiesConstraint {
 				ui.Info(fmt.Sprintf("SDK version %s: OK.", SDKVersion))


### PR DESCRIPTION
I just instinctively tried to run this in a directory where I have a provider cloned to see slightly confusing output:

```
Checking Go version used in provider...
2019/07/22 15:33:58 no Go version found in .go-version file for /Users/radeksimko/gopath/src: open /Users/radeksimko/gopath/src/.go-version: no such file or directory
2019/07/22 15:33:58 no go version found in go.mod file for /Users/radeksimko/gopath/src: open /Users/radeksimko/gopath/src/go.mod: no such file or directory
2019/07/22 15:33:58 no go version found in Travis config file for /Users/radeksimko/gopath/src: open /Users/radeksimko/gopath/src/.travis.yaml: no such file or directory
2019/07/22 15:33:58 failed to detect Go version for provider /Users/radeksimko/gopath/src
Go version does not satisfy constraint >=1.12. Found Go version: .
```

I'm not sure if there was a reason for the explicitness so feel free to object this - maybe we just need to improve the error reporting. 🤷‍♂ 😃 